### PR TITLE
remove boolean flip to prevent it being negated twice

### DIFF
--- a/packages/ui/src/components/forms/multiselect/MultiSelect.vue
+++ b/packages/ui/src/components/forms/multiselect/MultiSelect.vue
@@ -164,8 +164,8 @@ export const ForgeMultiSelect = /*#__PURE__*/ Vue.extend({
       } else {
         const selection = [...this.$attrs.options];
         this.$emit('input', selection);
+        this.isAllSelected = true;
       }
-      this.isAllSelected = !this.isAllSelected;
     }
   }
 });


### PR DESCRIPTION
this moves the boolean change into the else case, because when you call selectAll() with isAllSelected = true right now, it will then call clearSelected, which is fine. However, inside that method, the isAllSelected boolean will get set to false already, once its done and the flow goes back to the selectAll(), we can see that after if/else the boolean is flipped *again* causing the selectAll to not work once all have been selected

to reproduce the error try the following:

In playground:
1. go to multiselect
2. Enable "multiple"
3. Select "toggle all"
4. Trying selecting it again to unselect all and observe this not working