### PR TITLE
remove boolean flip to prevent it being negated twice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13452,7 +13452,7 @@
     },
     "packages/ui": {
       "name": "@3squared/forge-ui",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@3squared/forge-ui",
   "repository": "https://github.com/3Squared/ForgeUI",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "ForgeUI is designed to be a wrapper around different libraries that provide a consistent UI style. It is comprised of many different packages that have been combined to create a one stop shop for UI.",
   "license": "MIT",
   "main": "./dist/esm/forge-ui.mjs",

--- a/packages/ui/src/components/forms/multiselect/MultiSelect.vue
+++ b/packages/ui/src/components/forms/multiselect/MultiSelect.vue
@@ -164,8 +164,8 @@ export const ForgeMultiSelect = /*#__PURE__*/ Vue.extend({
       } else {
         const selection = [...this.$attrs.options];
         this.$emit('input', selection);
+        this.isAllSelected = true;
       }
-      this.isAllSelected = !this.isAllSelected;
     }
   }
 });


### PR DESCRIPTION
this moves the boolean change into the else case, because when you call selectAll() with isAllSelected = true right now, it will then call clearSelected, which is fine. However, inside that method, the isAllSelected boolean will get set to false already, once its done and the flow goes back to the selectAll(), we can see that after if/else the boolean is flipped again causing the selectAll to not work once all have been selected

to reproduce the error try the following:

In playground:

    go to multiselect
    Enable "multiple"
    Select "toggle all"
    Trying selecting it again to unselect all and observe this not working
