### PR TITLE
Add variant type global config for loader

### DIFF
--- a/.changeset/slow-mice-fetch.md
+++ b/.changeset/slow-mice-fetch.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui": patch
+---
+
+Add variant type configuration for loader

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@changesets/cli": "^2.26.0",
+        "@changesets/cli": "2.26.0",
         "eslint": "8.22.0",
         "eslint-config-custom": "*",
         "prettier": "^2.5.1",

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -40,6 +40,7 @@ type StepperConfig = VariantConfig;
 type MultiSelectConfig = VariantConfig;
 type StatWidgetConfig = VariantConfig;
 type FilterHeaderConfig = VariantConfig;
+type LoaderConfig = VariantConfig;
 
 interface DatePickerConfig extends VariantConfig {
   hideCalendarIcon?: false;
@@ -51,6 +52,7 @@ interface ForgeGlobalConfig {
   MultiSelect?: MultiSelectConfig;
   StatWidget?: StatWidgetConfig;
   FilterHeader?: FilterHeaderConfig;
+  Loader?: LoaderConfig;
 }
 
 const ForgeGlobalConfigPlugin: PluginObject<any> = {

--- a/packages/ui/src/components/general/loader/Loader.vue
+++ b/packages/ui/src/components/general/loader/Loader.vue
@@ -20,7 +20,7 @@ export const ForgeLoader = /*#__PURE__*/ Vue.extend({
     },
     variant: {
       type: String,
-      default: () => Vue.prototype?.ForgeSettings?.StatWidget?.variant ?? "primary"
+      default: () => Vue.prototype?.ForgeSettings?.Loader?.variant ?? "primary"
     }
   }
 });


### PR DESCRIPTION
Also added test case for variants. However, during cypress runs, the styling wasn't loading, so I went in and try to fix it. Mostly this issue cropped up due to paths being off. I'm not sure my fix is correct here, but opening this up anyway, so people can have a look at it