### PR TITLE
fix multiselect search being present even when all items are selected

### DIFF
--- a/.changeset/smooth-bears-happen.md
+++ b/.changeset/smooth-bears-happen.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui": patch
+---
+
+Ensure multiselect search disappears when all items are selected

--- a/packages/ui/src/components/forms/multiselect/MultiSelect.vue
+++ b/packages/ui/src/components/forms/multiselect/MultiSelect.vue
@@ -119,8 +119,12 @@ export const ForgeMultiSelect = /*#__PURE__*/ Vue.extend({
         allowEmpty: true,
         ...this.multiSelectDefaults,
         ...this.$attrs,
+        searchable: this.shouldDisplaySearch,
         value: this.selectValue ? options.filter(o => this.$attrs.value && this.$attrs.value.includes(o[this.selectValue])) : this.$attrs.value
       };
+    },
+    shouldDisplaySearch(): boolean {
+      return (this.$attrs.searchable == null || this.$attrs.searchable as unknown as boolean) && !this.isAllSelected;
     },
     optionHighlight(): string {
       return 'multiselect__option' +


### PR DESCRIPTION
I'm not sure if people want to keep the search around for whatever reason, should we put this behind or prop or is it fine?

Fixes #51 