### PR TITLE
explicitly pass content type from uploader to blob storage

### DIFF
--- a/.changeset/lazy-baboons-notice.md
+++ b/.changeset/lazy-baboons-notice.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui": patch
+---
+
+Fix uploader not passing content type to blob storage

--- a/packages/ui/src/components/forms/file-upload/components/FileInfo.vue
+++ b/packages/ui/src/components/forms/file-upload/components/FileInfo.vue
@@ -241,6 +241,10 @@ export const FileInfo = /*#__PURE__*/ Vue.extend({
           const options = {
             abortSignal: this.controller.signal,
             onProgress: this.onFileUploadProgress,
+            blobHTTPHeaders: {
+              blobContentType: this.file.type,
+              blobContentDisposition: `attachment; filename="${this.file.name}"`
+            },
             tags: { temp: "true" }
           } as BlockBlobParallelUploadOptions;
 


### PR DESCRIPTION
 to ensure browsers can interact with this file correctly