### PR TITLE
Update File Info to include extra mime types not catered for by the …

### DIFF
--- a/.changeset/short-owls-drop.md
+++ b/.changeset/short-owls-drop.md
@@ -1,0 +1,5 @@
+---
+"@3squared/forge-ui": minor
+---
+
+Updated the file mimetype definitions to use an external mime npm package, as bnrowsers do not like all file types. This was then upsetting the allowed file types by comparing an empty string, to the valid mime-types provided. The extra definitions should cater for a wider range of file types allowed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10740,6 +10740,20 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
+      "integrity": "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -16130,7 +16144,7 @@
     },
     "packages/ui": {
       "name": "@3squared/forge-ui",
-      "version": "1.9.3",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -16141,6 +16155,7 @@
         "dayjs": "^1.0.0",
         "flatpickr": "^4.0.0",
         "lodash": "4.17.21",
+        "mime": "^4.0.4",
         "ts-simple-nameof": "^1.0.0",
         "vee-validate": "3.4.15",
         "vue": "~2.7.0",
@@ -16504,6 +16519,7 @@
         "flatpickr": "^4.0.0",
         "fs-extra": "11.2.0",
         "lodash": "4.17.21",
+        "mime": "^4.0.4",
         "sass": "1.77.4",
         "shelljs": "0.8.5",
         "ts-simple-nameof": "^1.0.0",
@@ -24734,6 +24750,11 @@
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
       }
+    },
+    "mime": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
+      "integrity": "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ=="
     },
     "mime-db": {
       "version": "1.52.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,6 +35,7 @@
     "dayjs": "^1.0.0",
     "flatpickr": "^4.0.0",
     "lodash": "4.17.21",
+    "mime": "^4.0.4",
     "ts-simple-nameof": "^1.0.0",
     "vee-validate": "3.4.15",
     "vue": "~2.7.0",
@@ -42,23 +43,24 @@
     "vuedraggable": "2.24.3"
   },
   "devDependencies": {
-    "eslint-config-custom": "*",
-    "vite-plugin-checker": "0.6.4",
     "@cypress/code-coverage": "3.12.39",
     "@types/lodash": "4.17.5",
     "@vitejs/plugin-vue2": "2.3.1",
     "@vitest/coverage-v8": "0.34.6",
     "@vitest/ui": "0.34.7",
     "@vue/babel-preset-jsx": "1.4.0",
+    "@vue/test-utils": "1.3.6",
     "@zerollup/ts-transform-paths": "1.7.18",
     "agadoo": "3.0.0",
     "c8": "9.1.0",
     "cypress": "13.11.0",
+    "eslint-config-custom": "*",
     "fs-extra": "11.2.0",
     "sass": "1.77.4",
     "shelljs": "0.8.5",
     "typescript": "4.9.5",
     "vite": "4.5.3",
+    "vite-plugin-checker": "0.6.4",
     "vite-plugin-dts": "3.9.1",
     "vite-plugin-istanbul": "5.0.0",
     "vitest": "0.34.6",
@@ -66,8 +68,7 @@
     "vue-docgen-cli": "4.79.0",
     "vue-docgen-web-types": "0.1.8",
     "vue-template-compiler": "2.7.16",
-    "vue-tsc": "1.8.27",
-    "@vue/test-utils": "1.3.6"
+    "vue-tsc": "1.8.27"
   },
   "engines": {
     "node": ">=14"

--- a/packages/ui/src/components/forms/file-upload/components/FileInfo.vue
+++ b/packages/ui/src/components/forms/file-upload/components/FileInfo.vue
@@ -199,7 +199,7 @@ export const FileInfo = /*#__PURE__*/ Vue.extend({
       if (this.file.type) {
         return this.file.type;
       }
-      return forgeMime.getType(this.file.name);
+      return forgeMime().getType(this.file.name);
     }
   },
   mounted() {

--- a/packages/ui/src/components/forms/file-upload/components/FileInfo.vue
+++ b/packages/ui/src/components/forms/file-upload/components/FileInfo.vue
@@ -196,7 +196,7 @@ export const FileInfo = /*#__PURE__*/ Vue.extend({
       return getFileType(this.file.name);
     },
     fileMimeType(): string | null {
-      if(this.file.type){
+      if (this.file.type) {
         return this.file.type;
       }
       return forgeMime.getType(this.file.name);

--- a/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
+++ b/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
@@ -1,14 +1,11 @@
 ﻿import { Mime } from "mime";
 import standardTypes from "mime/types/standard.js";
 import otherTypes from "mime/types/other.js";
-let mime = null as Mime | null;
 
-export function forgeMime(): Mime {
-  if (mime == null) {
-    mime = new Mime(standardTypes, otherTypes);
-    mime.define({ "application/vnd.ms-outlook": ["pst"] });
-  }
-  return mime;
+export function forgeMime() : Mime {
+  const mime = new Mime(standardTypes, otherTypes)
+  mime.define({ "application/vnd.ms-outlook": ["pst"] })
+  return mime
 }
 
 export function formatFileSize(bytes: number, si = true, dp = 1) {

--- a/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
+++ b/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
@@ -1,11 +1,15 @@
 ﻿import { Mime } from "mime";
-
 import standardTypes from "mime/types/standard.js";
 import otherTypes from "mime/types/other.js";
-const forgeMime = new Mime(standardTypes, otherTypes);
-forgeMime.define({ "application/vnd.ms-outlook": ["pst"] });
+let mime = null as Mime | null;
 
-export { forgeMime };
+export function forgeMime(): Mime {
+  if(mime == null) {
+    mime = new Mime(standardTypes, otherTypes);
+    mime.define({ "application/vnd.ms-outlook": ["pst"] });
+  }
+  return mime;
+}
 
 export function formatFileSize(bytes: number, si = true, dp = 1) {
   const thresh = si ? 1000 : 1024;

--- a/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
+++ b/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
@@ -4,7 +4,7 @@ import otherTypes from "mime/types/other.js";
 let mime = null as Mime | null;
 
 export function forgeMime(): Mime {
-  if(mime == null) {
+  if (mime == null) {
     mime = new Mime(standardTypes, otherTypes);
     mime.define({ "application/vnd.ms-outlook": ["pst"] });
   }

--- a/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
+++ b/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
@@ -50,7 +50,7 @@ export function getFileType(fileName: string) {
   return fileType;
 }
 
-const iconFilesTypes = ["mp4", "wmv", "m4v", "mov", "mp3", "wav", "wma", "xls", "xlsx", "xps", "doc", "pdf", "docx"];
+const iconFilesTypes = ["mp4", "wmv", "m4v", "mov", "mp3", "wav", "wma", "xls", "xlsx", "xps", "doc", "pdf", "docx", "msg", "pst", "eml"];
 export function getReplacementImage(fileName: string) {
   const ext = fileExtension(fileName) as string;
   const iconExists = iconFilesTypes.includes(ext);

--- a/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
+++ b/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
@@ -2,10 +2,10 @@
 import standardTypes from "mime/types/standard.js";
 import otherTypes from "mime/types/other.js";
 
-export function forgeMime() : Mime {
-  const mime = new Mime(standardTypes, otherTypes)
-  mime.define({ "application/vnd.ms-outlook": ["pst"] })
-  return mime
+export function forgeMime(): Mime {
+  const mime = new Mime(standardTypes, otherTypes);
+  mime.define({ "application/vnd.ms-outlook": ["pst"] });
+  return mime;
 }
 
 export function formatFileSize(bytes: number, si = true, dp = 1) {

--- a/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
+++ b/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
@@ -1,4 +1,13 @@
-﻿export function formatFileSize(bytes: number, si = true, dp = 1) {
+﻿import { Mime } from 'mime';
+
+import standardTypes from 'mime/types/standard.js';
+import otherTypes from 'mime/types/other.js';
+const forgeMime = new Mime(standardTypes, otherTypes);
+forgeMime.define({'application/vnd.ms-outlook': ['pst']});
+
+export {forgeMime};
+
+export function formatFileSize(bytes: number, si = true, dp = 1) {
   const thresh = si ? 1000 : 1024;
 
   if (Math.abs(bytes) < thresh) {

--- a/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
+++ b/packages/ui/src/components/forms/file-upload/utils/fileUtilities.ts
@@ -1,11 +1,11 @@
-﻿import { Mime } from 'mime';
+﻿import { Mime } from "mime";
 
-import standardTypes from 'mime/types/standard.js';
-import otherTypes from 'mime/types/other.js';
+import standardTypes from "mime/types/standard.js";
+import otherTypes from "mime/types/other.js";
 const forgeMime = new Mime(standardTypes, otherTypes);
-forgeMime.define({'application/vnd.ms-outlook': ['pst']});
+forgeMime.define({ "application/vnd.ms-outlook": ["pst"] });
 
-export {forgeMime};
+export { forgeMime };
 
 export function formatFileSize(bytes: number, si = true, dp = 1) {
   const thresh = si ? 1000 : 1024;

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig(({ mode }) => ({
         "dayjs",
         "flatpickr",
         "lodash/cloneDeep",
+        "mime",
         "ts-simple-nameof",
         "vee-validate",
         "vee-validate/dist/rules",


### PR DESCRIPTION
…browser

- Add in a computed value for the mime type based on the file.type of the mapping using the mime npm package
- Use the computed value for setting the mime value when sending file to blob storage
- Add extra custom mapping in mime types to also include .pst files